### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,16 +3,16 @@ buildscript {
         mavenLocal()
         mavenCentral()
         maven {
-            url "http://repo.spring.io/snapshot"
+            url "https://repo.spring.io/snapshot"
         }
         maven {
-            url "http://repo.spring.io/milestone"
+            url "https://repo.spring.io/milestone"
         }
         maven {
-            url "http://repo.spring.io/libs-release-local"
+            url "https://repo.spring.io/libs-release-local"
         }
         maven {
-            url "http://repo.spring.io/libs-staging-local/"
+            url "https://repo.spring.io/libs-staging-local/"
         }
     }
     dependencies {
@@ -46,16 +46,16 @@ configure(subprojects) {
         mavenLocal()
         jcenter()
         maven {
-            url "http://repo.spring.io/snapshot"
+            url "https://repo.spring.io/snapshot"
         }
         maven {
-            url "http://repo.spring.io/milestone"
+            url "https://repo.spring.io/milestone"
         }
         maven {
-            url "http://repo.spring.io/libs-release-local"
+            url "https://repo.spring.io/libs-release-local"
         }
         maven {
-            url "http://repo.spring.io/libs-staging-local/"
+            url "https://repo.spring.io/libs-staging-local/"
         }
     }
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repo.spring.io/libs-staging-local/ with 2 occurrences migrated to:  
  https://repo.spring.io/libs-staging-local/ ([https](https://repo.spring.io/libs-staging-local/) result 200).
* http://repo.spring.io/libs-release-local with 2 occurrences migrated to:  
  https://repo.spring.io/libs-release-local ([https](https://repo.spring.io/libs-release-local) result 302).
* http://repo.spring.io/milestone with 2 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).