### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Sleuth documentation apps
 
-[Apps used for the Sleuth documentation graphs](http://cloud.spring.io/spring-cloud-sleuth/spring-cloud-sleuth.html) . They're not using
+[Apps used for the Sleuth documentation graphs](https://cloud.spring.io/spring-cloud-sleuth/spring-cloud-sleuth.html) . They're not using
 service discovery so don't treat them as reference production applications ;)
 
 The apps are sending spans to Zipkin via RabbitMQ and `spring-cloud-sleuth-stream`.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-sleuth/spring-cloud-sleuth.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-sleuth/spring-cloud-sleuth.html ([https](https://cloud.spring.io/spring-cloud-sleuth/spring-cloud-sleuth.html) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 2 occurrences
* http://localhost:8081 with 1 occurrences